### PR TITLE
fix error-catching tests

### DIFF
--- a/triangle/triangle_test.spec.coffee
+++ b/triangle/triangle_test.spec.coffee
@@ -45,22 +45,22 @@ describe "Triangle", ->
     try
       new Triangle(2,3,-5)
     catch error
-      expect(error).toBe "negative sides are illegal"
+    expect(error).toBe "negative sides are illegal"
 
   xit 'is illegal when violating triangle inequality', ->
     try
       new Triangle(1,1,3)
     catch error
-      expect(error).toBe "violation of triangle inequality"
+    expect(error).toBe "violation of triangle inequality"
 
   xit 'is illegal when violating triangle inequality 2', ->
     try
       new Triangle(2,2,4)
     catch error
-      expect(error).toBe "violation of triangle inequality"
+    expect(error).toBe "violation of triangle inequality"
 
   xit 'is illegal when violating triangle inequality 3', ->
     try
       new Triangle(7,3,2)
     catch error
-      expect(error).toBe "violation of triangle inequality"
+    expect(error).toBe "violation of triangle inequality"


### PR DESCRIPTION
I was finding that the pending tests which attempt to test the illegal triangle dimensions weren't properly failing if `new Triangle()` never throws, thus skipping the expectation. Moving the expectation so it's not inside the `catch` block means it still gets run even if the `catch` block doesn't.
