### PR TITLE
fix error-catching in nth-prime and queen-attack

### DIFF
--- a/nth-prime/nth_prime_test.spec.coffee
+++ b/nth-prime/nth_prime_test.spec.coffee
@@ -22,4 +22,4 @@ describe 'Prime', ->
     try
       Prime.nth(0)
     catch error
-      expect(error).toEqual("Prime is not possible")
+    expect(error).toEqual("Prime is not possible")

--- a/queen-attack/queen_attack_test.spec.coffee
+++ b/queen-attack/queen_attack_test.spec.coffee
@@ -18,7 +18,7 @@ describe "Queens", ->
     try
       queens = new Queens(positioning)
     catch error
-      expect(error).toEqual("Queens cannot share the same space")
+    expect(error).toEqual("Queens cannot share the same space")
 
 
   xit "toString representation", ->


### PR DESCRIPTION
Similar to #16, here are two more tests which attempt to catch an error, but aren't properly failing because of whitespace.
