### PR TITLE
prefer "expect(...).toThrow" over "try ... catch" in tests

### DIFF
--- a/nth-prime/nth_prime_test.spec.coffee
+++ b/nth-prime/nth_prime_test.spec.coffee
@@ -19,7 +19,4 @@ describe 'Prime', ->
     expect(prime).toEqual(104743)
 
   xit 'weird case', ->
-    try
-      Prime.nth(0)
-    catch error
-    expect(error).toEqual("Prime is not possible")
+    expect(-> Prime.nth(0)).toThrow("Prime is not possible")

--- a/queen-attack/queen_attack_test.spec.coffee
+++ b/queen-attack/queen_attack_test.spec.coffee
@@ -14,11 +14,7 @@ describe "Queens", ->
 
   xit "cannot occupy the same space", ->
     positioning = { white: [2,4], black: [2,4] }
-
-    try
-      queens = new Queens(positioning)
-    catch error
-    expect(error).toEqual("Queens cannot share the same space")
+    expect(-> new Queens(positioning)).toThrow("Queens cannot share the same space")
 
 
   xit "toString representation", ->

--- a/triangle/triangle_test.spec.coffee
+++ b/triangle/triangle_test.spec.coffee
@@ -42,25 +42,13 @@ describe "Triangle", ->
     expect(triangle.kind()).toBe 'scalene'
 
   xit 'is illegal when a side is negative', ->
-    try
-      new Triangle(2,3,-5)
-    catch error
-    expect(error).toBe "negative sides are illegal"
+    expect(-> new Triangle(2,3,-5)).toThrow("negative sides are illegal")
 
   xit 'is illegal when violating triangle inequality', ->
-    try
-      new Triangle(1,1,3)
-    catch error
-    expect(error).toBe "violation of triangle inequality"
+    expect(-> new Triangle(1,1,3)).toThrow("violation of triangle inequality")
 
   xit 'is illegal when violating triangle inequality 2', ->
-    try
-      new Triangle(2,2,4)
-    catch error
-    expect(error).toBe "violation of triangle inequality"
+    expect(-> new Triangle(2,2,4)).toThrow("violation of triangle inequality")
 
   xit 'is illegal when violating triangle inequality 3', ->
-    try
-      new Triangle(7,3,2)
-    catch error
-    expect(error).toBe "violation of triangle inequality"
+    expect(-> new Triangle(7,3,2)).toThrow("violation of triangle inequality")


### PR DESCRIPTION
This addresses the same issue mentioned in #16 and #18. This version places the expectation on the behavior rather than relying on error handling in the body of the test.
