### PR TITLE
un-pend first test of palindrome-products

### DIFF
--- a/palindrome-products/palindrome_products_test.spec.coffee
+++ b/palindrome-products/palindrome_products_test.spec.coffee
@@ -2,7 +2,7 @@ Palindromes = require('./palindromes')
 
 describe "Palindrome", ->
 
-  xit "largest palindrome from single digit factors", ->
+  it "largest palindrome from single digit factors", ->
     palindromes = new Palindromes({maxFactor: 9})
     palindromes.generate()
     largest = palindromes.largest()


### PR DESCRIPTION
Other test suites have just the first test running, and all the others pending with `xit`.
