### PR TITLE
s/Woah/Whoa/ in specs for Bob

### DIFF
--- a/bob/bob_test.spec.coffee
+++ b/bob/bob_test.spec.coffee
@@ -27,7 +27,7 @@ describe "Bob", ->
 
   xit "shouting numbers", ->
     result = bob.hey "1, 2, 3 GO!"
-    expect(result).toEqual "Woah, chill out!"
+    expect(result).toEqual "Whoa, chill out!"
 
   xit "only number", ->
     result = bob.hey "1, 2, 3"


### PR DESCRIPTION
This must be a mistake, your example will never pass the spec as long as there's a `Woah`.

@austinlyons please sign this off and +1 to speed up deployment of this fix. Cheers!
