### PR TITLE
Adds test for non-binary ints inside of the string

### DIFF
--- a/binary/binary_test.spec.coffee
+++ b/binary/binary_test.spec.coffee
@@ -25,3 +25,6 @@ describe 'binary', ->
 
   xit 'carrot is decimal 0', ->
     expect(new Binary('carrot').toDecimal()).toEqual 0
+
+  xit 'numeric but non-binary string is decimal 0', ->
+    expect(new Binary('42').toDecimal()).toEqual 0


### PR DESCRIPTION
The method is expected to check for non-binary ints inside
of the input string and should return 0 then.

Idea from @Flambino through [this nitpick](http://exercism.io/submissions/55108b0e410574056c2737b7)
