### PR TITLE
Reformat 'about' documentation for nextercism

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,14 +1,9 @@
 JavaScript is a great language, but not everyone likes writing in it. Thus, people and organizations have started to write languages that transpile (transpiling keeps the same level of abstraction, compiling decreases the level of abstraction) into JavaScript, that they feel are nicer to write in than JavaScript. CoffeeScript is one example, another is Microsoft's TypeScript.
 
-What are the specific advantages of CoffeeScript? From [coffeescript.org](http://www.coffeescript.org):
+CoffeeScript is a little language that compiles into JavaScript. Underneath that awkward Java-esque patina, JavaScript has always had a gorgeous heart. CoffeeScript is an attempt to expose the good parts of JavaScript in a simple way.
 
-> CoffeeScript is a little language that compiles into JavaScript. Underneath that awkward Java-esque patina,
-> JavaScript has always had a gorgeous heart. CoffeeScript is an attempt to expose the good parts of JavaScript
-> in a simple way.
->
-> The golden rule of CoffeeScript is: "It's just JavaScript". The code compiles one-to-one into the equivalent JS,
-> and there is no interpretation at runtime. You can use any existing JavaScript library seamlessly from CoffeeScript
-> (and vice-versa). The compiled output is readable and pretty-printed, will work in every JavaScript runtime, and tends
-> to run as fast or faster than the equivalent handwritten JavaScript.
+The golden rule of CoffeeScript is: "It's just JavaScript". The code compiles one-to-one into the equivalent JS, and there is no interpretation at runtime. You can use any existing JavaScript library seamlessly from CoffeeScript (and vice-versa). The compiled output is readable and pretty-printed, will work in every JavaScript runtime, and tends to run as fast or faster than the equivalent handwritten JavaScript.
 
 You should learn CoffeeScript if you like programming in JavaScript, and want to experiment with a different way to write it. With transpiled versions of JavaScript (ECMA 2015, TypeScript, etc) becoming more popular, this is a valuable skill for a coder.
+
+_(Info taken from [coffeescript.org](http://www.coffeescript.org))_


### PR DESCRIPTION
Hello. I'm trying to get all of the ABOUT.md files reformatted to fit with the new look and feel of nextercism. This means removing things like line-breaks and markdown that we're not supporting.

As an example from the C++ Track, we've gone from:
<img width="1167" alt="screen shot 2017-08-06 at 15 16 34" src="https://user-images.githubusercontent.com/286476/29004482-b990fad8-7abf-11e7-98c5-cc3f2f1ee3e8.png">
to:
<img width="1161" alt="screen shot 2017-08-06 at 15 15 43" src="https://user-images.githubusercontent.com/286476/29004485-c26acf6c-7abf-11e7-90f1-575b2edd5316.png">

As a general note, after these formatting changes get merged, we're hoping that track
maintainers will take some time to review the contents of the ABOUT.md file and edit
it to make it a bit shorter and more casual. We're looking for less wikipedia and more
of an enthusiastic and friendly pitch that you might make to a friend over a drink for
why they should try the language.

For some examples of tracks where I think they've done this well take a look at the
Go and R tracks:
- https://github.com/exercism/go/blob/master/docs/ABOUT.md
- https://github.com/exercism/r/blob/3f05539d19d7e20d2a9d5cd2cecd3dc56f4f23e8/docs/ABOUT.md

See https://github.com/exercism/meta/issues/84 for more details.

Thank you!