### PR TITLE
Inline the exercise README insert

### DIFF
--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -4,10 +4,13 @@
 {{- with .Hints }}
 {{ . }}
 {{ end }}
-{{- with .TrackInsert }}
-{{ . }}
-{{ end }}
-{{- with .Spec.Credits -}}
+Refer to the [Exercism CoffeScript page](http://exercism.io/languages/coffeescript) for getting started with CoffeeScript.
+
+In order to run the test, you can run the test file from the exercise directory:
+```bash
+jasmine-node --coffee .
+```
+{{ with .Spec.Credits }}
 ## Source
 
 {{ . }}

--- a/docs/EXERCISE_README_INSERT.md
+++ b/docs/EXERCISE_README_INSERT.md
@@ -1,6 +1,0 @@
-Refer to the [Exercism CoffeScript page](http://exercism.io/languages/coffeescript) for getting started with CoffeeScript.
-
-In order to run the test, you can run the test file from the exercise directory:
-```bash
-jasmine-node --coffee .
-```

--- a/exercises/accumulate/README.md
+++ b/exercises/accumulate/README.md
@@ -25,9 +25,6 @@ Keep your hands off that collect/map/fmap/whatchamacallit functionality
 provided by your standard library!
 Solve this one yourself using other basic tools instead.
 
-Lisp specific: it's perfectly fine to use `MAPCAR` or the equivalent,
-as this is idiomatic Lisp, not a library function.
-
 Refer to the [Exercism CoffeScript page](http://exercism.io/languages/coffeescript) for getting started with CoffeeScript.
 
 In order to run the test, you can run the test file from the exercise directory:

--- a/exercises/atbash-cipher/README.md
+++ b/exercises/atbash-cipher/README.md
@@ -9,7 +9,7 @@ letter, the second with the second-last, and so on.
 
 An Atbash cipher for the Latin alphabet would be as follows:
 
-```plain
+```text
 Plain:  abcdefghijklmnopqrstuvwxyz
 Cipher: zyxwvutsrqponmlkjihgfedcba
 ```
@@ -23,6 +23,7 @@ being 5 letters, and punctuation is excluded. This is to make it harder to guess
 things based on word boundaries.
 
 ## Examples
+
 - Encoding `test` gives `gvhg`
 - Decoding `gvhg` gives `test`
 - Decoding `gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt` gives `thequickbrownfoxjumpsoverthelazydog`

--- a/exercises/beer-song/README.md
+++ b/exercises/beer-song/README.md
@@ -1,10 +1,10 @@
 # Beer Song
 
-Produce the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.
+Recite the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.
 
 Note that not all verses are identical.
 
-```plain
+```text
 99 bottles of beer on the wall, 99 bottles of beer.
 Take one down and pass it around, 98 bottles of beer on the wall.
 

--- a/exercises/binary/README.md
+++ b/exercises/binary/README.md
@@ -7,10 +7,12 @@ string, your program should produce a decimal output. The
 program should handle invalid inputs.
 
 ## Note
+
 - Implement the conversion yourself.
   Do not use something else to perform the conversion for you.
 
 ## About Binary (Base-2)
+
 Decimal is a base-10 system.
 
 A number 23 in base 10 notation can be understood

--- a/exercises/linked-list/README.md
+++ b/exercises/linked-list/README.md
@@ -2,18 +2,18 @@
 
 Implement a doubly linked list.
 
-Like an array, a linked list is a simple linear data structure. Several 
-common data types can be implemented using linked lists, like queues, 
+Like an array, a linked list is a simple linear data structure. Several
+common data types can be implemented using linked lists, like queues,
 stacks, and associative arrays.
 
-A linked list is a collection of data elements called *nodes*. In a 
-*singly linked list* each node holds a value and a link to the next node. 
-In a *doubly linked list* each node also holds a link to the previous 
+A linked list is a collection of data elements called *nodes*. In a
+*singly linked list* each node holds a value and a link to the next node.
+In a *doubly linked list* each node also holds a link to the previous
 node.
 
-You will write an implementation of a doubly linked list. Implement a 
-Node to hold a value and pointers to the next and previous nodes. Then 
-implement a List which holds references to the first and last node and 
+You will write an implementation of a doubly linked list. Implement a
+Node to hold a value and pointers to the next and previous nodes. Then
+implement a List which holds references to the first and last node and
 offers an array-like interface for adding and removing items:
 
 * `push` (*insert value at back*);
@@ -21,8 +21,8 @@ offers an array-like interface for adding and removing items:
 * `shift` (*remove value at front*).
 * `unshift` (*insert value at front*);
 
-To keep your implementation simple, the tests will not cover error 
-conditions. Specifically: `pop` or `shift` will never be called on an 
+To keep your implementation simple, the tests will not cover error
+conditions. Specifically: `pop` or `shift` will never be called on an
 empty list.
 
 If you want to know more about linked lists, check [Wikipedia](https://en.wikipedia.org/wiki/Linked_list).

--- a/exercises/luhn/README.md
+++ b/exercises/luhn/README.md
@@ -18,27 +18,27 @@ are disallowed.
 
 ## Example 1: valid credit card number
 
-```
+```text
 4539 1488 0343 6467
 ```
 
 The first step of the Luhn algorithm is to double every second digit,
 starting from the right. We will be doubling
 
-```
+```text
 4_3_ 1_8_ 0_4_ 6_6_
 ```
 
 If doubling the number results in a number greater than 9 then subtract 9
 from the product. The results of our doubling:
 
-```
+```text
 8569 2478 0383 3437
 ```
 
 Then sum all of the digits:
 
-```
+```text
 8+5+6+9+2+4+7+8+0+3+8+3+3+4+3+7 = 80
 ```
 
@@ -46,19 +46,19 @@ If the sum is evenly divisible by 10, then the number is valid. This number is v
 
 ## Example 2: invalid credit card number
 
-```
+```text
 8273 1232 7352 0569
 ```
 
 Double the second digits, starting from the right
 
-```
+```text
 7253 2262 5312 0539
 ```
 
 Sum the digits
 
-```
+```text
 7+2+5+3+2+2+6+2+5+3+1+2+0+5+3+9 = 57
 ```
 

--- a/exercises/nucleotide-count/README.md
+++ b/exercises/nucleotide-count/README.md
@@ -1,30 +1,16 @@
 # Nucleotide Count
 
-Given a DNA string, compute how many times each nucleotide occurs in the string.
+Given a single stranded DNA string, compute how many times each nucleotide occurs in the string.
 
-DNA is represented by an alphabet of the following symbols: 'A', 'C',
-'G', and 'T'.
+The genetic language of every living thing on the planet is DNA.
+DNA is a large molecule that is built from an extremely long sequence of individual elements called nucleotides.
+4 types exist in DNA and these differ only slightly and can be represented as the following symbols: 'A' for adenine, 'C' for cytosine, 'G' for guanine, and 'T' thymine.
 
-Each symbol represents a nucleotide, which is a fancy name for the
-particular molecules that happen to make up a large part of DNA.
-
-Shortest intro to biochemistry EVAR:
-
+Here is an analogy:
 - twigs are to birds nests as
-- nucleotides are to DNA and RNA as
-- amino acids are to proteins as
-- sugar is to starch as
-- oh crap lipids
-
-I'm not going to talk about lipids because they're crazy complex.
-
-So back to nucleotides.
-
-DNA contains four types of them: adenine (`A`), cytosine (`C`), guanine
-(`G`), and thymine (`T`).
-
-RNA contains a slightly different set of nucleotides, but we don't care
-about that for now.
+- nucleotides are to DNA as
+- legos are to lego houses as
+- words are to sentences as...
 
 Refer to the [Exercism CoffeScript page](http://exercism.io/languages/coffeescript) for getting started with CoffeeScript.
 

--- a/exercises/palindrome-products/README.md
+++ b/exercises/palindrome-products/README.md
@@ -5,33 +5,32 @@ Detect palindrome products in a given range.
 A palindromic number is a number that remains the same when its digits are
 reversed. For example, `121` is a palindromic number but `112` is not.
 
-Given the definition of a palindromic number, we define a palindrome _product_
-to be the product `c`, such that `a * b = c`, where `c` is a palindromic number and
- `a` and `b` are integers (possibly, but _not_ necessarily palindromic numbers).
+Given a range of numbers, find the largest and smallest palindromes which
+are products of numbers within that range.
 
-For example, the palindromic number 9009 can be written as the palindrome
-product: `91 * 99 = 9009`.
-
-It's possible (and indeed common) for a palindrome product to be the product
-of multiple combinations of numbers. For example, the palindrome product `9` has
-the factors `(1, 9)`, `(3, 3)`, and `(9, 1)`.
-
-Write a program that given a range of integers, returns the smallest and largest
-palindromic product within that range, along with all of it's factors.
+Your solution should return the largest and smallest palindromes, along with the
+factors of each within the range. If the largest or smallest palindrome has more
+than one pair of factors within the range, then return all the pairs.
 
 ## Example 1
 
 Given the range `[1, 9]` (both inclusive)...
 
-The smallest product is `1`. It's factors are `(1, 1)`.
-The largest product is `9`. It's factors are `(1, 9)`, `(3, 3)`, and `(9, 1)`.
+And given the list of all possible products within this range:
+`[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16, 18, 15, 21, 24, 27, 20, 28, 32, 36, 25, 30, 35, 40, 45, 42, 48, 54, 49, 56, 63, 64, 72, 81]`
+
+The palindrome products are all single digit numbers (in this case):
+`[1, 2, 3, 4, 5, 6, 7, 8, 9]`
+
+The smallest palindrome product is `1`. Its factors are `(1, 1)`.
+The largest palindrome product is `9`. Its factors are `(1, 9)` and `(3, 3)`.
 
 ## Example 2
 
 Given the range `[10, 99]` (both inclusive)...
 
-The smallest palindrome product is `121`. It's factors are `(11, 11)`.
-The largest palindrome product is `9009`. It's factors are `(91, 99)` and `(99, 91)`.
+The smallest palindrome product is `121`. Its factors are `(11, 11)`.
+The largest palindrome product is `9009`. Its factors are `(91, 99)`.
 
 Refer to the [Exercism CoffeScript page](http://exercism.io/languages/coffeescript) for getting started with CoffeeScript.
 

--- a/exercises/pascals-triangle/README.md
+++ b/exercises/pascals-triangle/README.md
@@ -1,11 +1,11 @@
-# Pascals Triangle
+# Pascal's Triangle
 
 Compute Pascal's triangle up to a given number of rows.
 
 In Pascal's Triangle each number is computed by adding the numbers to
 the right and left of the current position in the previous row.
 
-```plain
+```text
     1
    1 1
   1 2 1

--- a/exercises/queen-attack/README.md
+++ b/exercises/queen-attack/README.md
@@ -11,7 +11,7 @@ A chessboard can be represented by an 8 by 8 array.
 So if you're told the white queen is at (2, 3) and the black queen at
 (5, 6), then you'd know you've got a set-up like so:
 
-```plain
+```text
 _ _ _ _ _ _ _ _
 _ _ _ _ _ _ _ _
 _ _ _ W _ _ _ _

--- a/exercises/triangle/README.md
+++ b/exercises/triangle/README.md
@@ -2,23 +2,26 @@
 
 Determine if a triangle is equilateral, isosceles, or scalene.
 
-An _equilateral_ triangle has all three sides the same length.<br/>
+An _equilateral_ triangle has all three sides the same length.
+
 An _isosceles_ triangle has at least two sides the same length. (It is sometimes
 specified as having exactly two sides the same length, but for the purposes of
-this exercise we'll say at least two.)<br/>
+this exercise we'll say at least two.)
+
 A _scalene_ triangle has all sides of different lengths.
 
 ## Note
 
-For a shape to be a triangle at all, all sides have to be of length > 0, and 
-the sum of the lengths of any two sides must be greater than or equal to the 
+For a shape to be a triangle at all, all sides have to be of length > 0, and
+the sum of the lengths of any two sides must be greater than or equal to the
 length of the third side. See [Triangle Inequality](https://en.wikipedia.org/wiki/Triangle_inequality).
 
 ## Dig Deeper
 
-The case where the sum of the lengths of two sides _equals_ that of the 
-third is known as a _degenerate_ triangle - it has zero area and looks like 
+The case where the sum of the lengths of two sides _equals_ that of the
+third is known as a _degenerate_ triangle - it has zero area and looks like
 a single line. Feel free to add your own code/tests to check for degenerate triangles.
+
 Refer to the [Exercism CoffeScript page](http://exercism.io/languages/coffeescript) for getting started with CoffeeScript.
 
 In order to run the test, you can run the test file from the exercise directory:

--- a/exercises/trinary/README.md
+++ b/exercises/trinary/README.md
@@ -11,7 +11,7 @@ Trinary numbers contain three symbols: 0, 1, and 2.
 The last place in a trinary number is the 1's place. The second to last
 is the 3's place, the third to last is the 9's place, etc.
 
-```bash
+```shell
 # "102012"
     1       0       2       0       1       2    # the number
 1*3^5 + 0*3^4 + 2*3^3 + 0*3^2 + 1*3^1 + 2*3^0    # the value

--- a/exercises/word-count/README.md
+++ b/exercises/word-count/README.md
@@ -4,13 +4,12 @@ Given a phrase, count the occurrences of each word in that phrase.
 
 For example for the input `"olly olly in come free"`
 
-```plain
+```text
 olly: 2
 in: 1
 come: 1
 free: 1
 ```
-
 
 Refer to the [Exercism CoffeScript page](http://exercism.io/languages/coffeescript) for getting started with CoffeeScript.
 

--- a/exercises/wordy/README.md
+++ b/exercises/wordy/README.md
@@ -2,7 +2,6 @@
 
 Parse and evaluate simple math word problems returning the answer as an integer.
 
-
 ## Iteration 1 — Addition
 
 Add two numbers together.
@@ -12,7 +11,6 @@ Add two numbers together.
 Evaluates to 18.
 
 Handle large numbers and negative numbers.
-
 
 ## Iteration 2 — Subtraction, Multiplication and Division
 
@@ -30,7 +28,6 @@ Now, perform the other three operations.
 
 5
 
-
 ## Iteration 3 — Multiple Operations
 
 Handle a set of operations, in sequence.
@@ -46,7 +43,6 @@ left-to-right, _ignoring the typical order of operations._
 
 15  (i.e. not 9)
 
-
 ## Bonus — Exponentials
 
 If you'd like, handle exponentials.
@@ -54,7 +50,6 @@ If you'd like, handle exponentials.
 > What is 2 raised to the 5th power?
 
 32
-
 
 Refer to the [Exercism CoffeScript page](http://exercism.io/languages/coffeescript) for getting started with CoffeeScript.
 


### PR DESCRIPTION
Now that we're operating with a track-wide template for generating exercise
READMEs we no longer need a separate markdown document to use for hints
and instructions that apply to all the exercises in a track. These instructions
can be defined directly in the template.

The first commit regenerates the exercise READMEs to pick up tweaks to problem descriptions, which have been updated with various formatting changes, whitespace changes, and clarifications to the description.

That gives us a clean diff when inlining the template and regenerating.

Ref: https://github.com/exercism/meta/issues/94