### PR TITLE
Add 'math' topic to relevant exercises in track config

### DIFF
--- a/config.json
+++ b/config.json
@@ -64,6 +64,7 @@
       "difficulty": 2,
       "topics": [
         "integers",
+        "math",
         "transforming"
       ]
     },
@@ -87,6 +88,7 @@
       "difficulty": 3,
       "topics": [
         "integers",
+        "math",
         "transforming"
       ]
     },
@@ -98,6 +100,7 @@
       "difficulty": 3,
       "topics": [
         "integers",
+        "math",
         "transforming"
       ]
     },
@@ -109,8 +112,7 @@
       "difficulty": 2,
       "topics": [
         "arrays",
-        "equality",
-        "mathematics"
+        "equality"
       ]
     },
     {
@@ -123,7 +125,6 @@
         "algorithms",
         "arrays",
         "integers",
-        "mathematics",
         "pattern_recognition"
       ]
     },
@@ -151,7 +152,7 @@
         "filter",
         "loops",
         "map",
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -163,7 +164,7 @@
       "topics": [
         "arrays",
         "integers",
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -187,7 +188,6 @@
       "difficulty": 4,
       "topics": [
         "integers",
-        "mathematics",
         "pattern_recognition",
         "regular_expressions",
         "strings"
@@ -202,7 +202,6 @@
       "topics": [
         "integers",
         "loops",
-        "mathematics",
         "text_formatting"
       ]
     },
@@ -254,7 +253,7 @@
         "algorithms",
         "arrays",
         "integers",
-        "mathematics"
+        "math"
       ]
     },
     {


### PR DESCRIPTION
The new site lets people filter optional exercises by topic, and this
makes it easy for people to skip past them.

This is important since the math-y exercises are not key to learning
the language, and a lot of people find them intimidating and demotivating.

This updates any 'mathematics' topics to be 'math' since it's shorter
and won't get cropped in the UI.

It also removes the math topics for any exercises that are not in the
canonical math-y list.


exercism/exercism.io#4110