### PR TITLE
fix triangle inequality test

### DIFF
--- a/exercises/triangle/triangle_test.spec.coffee
+++ b/exercises/triangle/triangle_test.spec.coffee
@@ -48,7 +48,7 @@ describe "Triangle", ->
     expect(-> new Triangle(1,1,3)).toThrow("violation of triangle inequality")
 
   xit 'is illegal when violating triangle inequality 2', ->
-    expect(-> new Triangle(2,2,4)).toThrow("violation of triangle inequality")
+    expect(-> new Triangle(2,2,5)).toThrow("violation of triangle inequality")
 
   xit 'is illegal when violating triangle inequality 3', ->
     expect(-> new Triangle(7,3,2)).toThrow("violation of triangle inequality")


### PR DESCRIPTION
A triangle with sides 2, 2, and 4 does not violate the triangle inequality:
>In mathematics, the triangle inequality states that for any triangle, the sum of the lengths of any two sides must be **greater than or equal** to the length of the remaining side.

So I've changed it to 2, 2, and 5.