### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 CoffeeScript is a language which transpiles into JavaScript, used for making dynamic websites (both in the web browser, and on the server). The transpiler is used to transform CoffeeScript code into JavaScript before running, to keep compability and the same performance of JavaScript while providing many new features!
 
 CoffeeScript was created to provide a simplified way to write JavaScript, based on a blend of the Ruby and Python languages. One difference is the use of indentation and arrows to replace JavaScript's verbose function code, and introduces useful features from functional languages including pattern matching.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,3 +1,5 @@
+# Installation
+
 **Windows and OS X users**: Install [Node.js](http://nodejs.org/) [via package manager](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager). Windows users can use a paid version of Visual Studio, see below.
 
 **Linux users**: [Joyent maintains a document][linstall] that details how to get Node.js installed for a wide range of distributions and package managers.

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,3 +1,5 @@
+# Resources
+
 ## Making Your First Node Module
 
 To create a module that can be loaded with `Bob = require './bob'`, put this code in `bob.coffee`:

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,4 +1,4 @@
-## Running Tests
+# Running Tests
 
 Execute the tests with:
 


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
