### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,25 @@
+{
+  "docs": [
+    {
+      "uuid": "dce0232f-83fc-4522-8700-198794974e6a",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing CoffeeScript locally",
+      "blurb": "Learn how to install CoffeeScript locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "18f06ec5-392b-45f5-8c4d-9d50f3ca1369",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the CoffeeScript track",
+      "blurb": "Learn how to test your CoffeeScript exercises on Exercism"
+    },
+    {
+      "uuid": "066497a1-7b20-4a67-98fa-ac52332d7a91",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful CoffeeScript resources",
+      "blurb": "A collection of useful resources to help you master CoffeeScript"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
