### PR TITLE
Convert backtick (`) admonition fences to tildes (~)

### DIFF
--- a/exercises/practice/linked-list/.docs/instructions.md
+++ b/exercises/practice/linked-list/.docs/instructions.md
@@ -13,7 +13,7 @@ Sometimes a station gets closed down, and in that case the station needs to be r
 
 The size of a route is measured not by how far the train travels, but by how many stations it stops at.
 
-```exercism/note
+~~~~exercism/note
 The linked list is a fundamental data structure in computer science, often used in the implementation of other data structures.
 As the name suggests, it is a list of nodes that are linked together.
 It is a list of "nodes", where each node links to its neighbor or neighbors.
@@ -23,4 +23,4 @@ In a **doubly linked list** each node links to both the node that comes before, 
 If you want to dig deeper into linked lists, check out [this article][intro-linked-list] that explains it using nice drawings.
 
 [intro-linked-list]: https://medium.com/basecs/whats-a-linked-list-anyway-part-1-d8b7e6508b9d
-```
+~~~~


### PR DESCRIPTION
In line with Exercism's spec, we're ensuring that all admonition fences are demarcated with four tildes (`~~~~`) across all repositories. We will be following up with an org-wide script that can be used to keep this consistent. [Problem Specifications](https://github.com/exercism/problem-specifications) has already been updated.

We'll automatically merge this a week from now, but feel free to merge beforehand!

- Spec: https://exercism.org/docs/building/markdown/markdown#h-special-blocks-sometimes-called-admonitions
- Meta issue: https://github.com/exercism/exercism/issues/6705