### PR TITLE
fixed protein-translation.spec.coffee

### DIFF
--- a/exercises/practice/protein-translation/protein-translation.spec.coffee
+++ b/exercises/practice/protein-translation/protein-translation.spec.coffee
@@ -134,4 +134,4 @@ describe 'ProteinTranslation', ->
   xit "Non-existing codon can't translate", ->
     expect ->
       ProteinTranslation.proteins("AAA")
-    .toThrow "Invalid codon"
+    .toThrow new Error("Invalid codon")


### PR DESCRIPTION
rewrote the last test to check for an exception and not a string like seen in other exercise tests.

Related to #259