### PR TITLE
get rid of escaped apostrophes after fixing the test runner

### DIFF
--- a/exercises/practice/binary-search/binary-search.spec.coffee
+++ b/exercises/practice/binary-search/binary-search.spec.coffee
@@ -37,13 +37,13 @@ describe 'Binary Search', ->
       new BinarySearch(array).find 7
     .toThrow new Error 'value not in array'
 
-  xit 'a value smaller than the array\'s smallest value is not found', ->
+  xit "a value smaller than the array's smallest value is not found", ->
     array = [1, 3, 4, 6, 8, 9, 11]
     expect ->
       new BinarySearch(array).find 0
     .toThrow new Error 'value not in array'
 
-  xit 'a value larger than the array\'s largest value is not found', ->
+  xit "a value larger than the array's largest value is not found", ->
     array = [1, 3, 4, 6, 8, 9, 11]
     expect ->
       new BinarySearch(array).find 13

--- a/exercises/practice/bob/bob.spec.coffee
+++ b/exercises/practice/bob/bob.spec.coffee
@@ -14,11 +14,11 @@ describe 'Bob', ->
     expect(result).toEqual 'Sure.'
 
   xit 'talking forcefully', ->
-    result = bob.hey 'Let\'s go make out behind the gym!'
+    result = bob.hey "Let's go make out behind the gym!"
     expect(result).toEqual 'Whatever.'
 
   xit 'using acronyms in regular speech', ->
-    result = bob.hey 'It\'s OK if you don\'t want to go to the DMV.'
+    result = bob.hey "It's OK if you don't want to go to the DMV."
     expect(result).toEqual 'Whatever.'
 
   xit 'forceful questions', ->

--- a/exercises/practice/hello-world/hello-world.spec.coffee
+++ b/exercises/practice/hello-world/hello-world.spec.coffee
@@ -3,6 +3,6 @@ HelloWorld = require './hello-world'
 describe 'HelloWorld', ->
   hello_world = new HelloWorld()
 
-  it 'says \'Hello, World!\'', ->
+  it "says 'Hello, World!'", ->
     result = hello_world.hello()
     expect(result).toEqual 'Hello, World!'

--- a/exercises/practice/luhn/luhn.spec.coffee
+++ b/exercises/practice/luhn/luhn.spec.coffee
@@ -74,14 +74,14 @@ describe 'Luhn', ->
     luhn = new Luhn('109')
     expect(luhn.valid()).toBe true
 
-  xit 'using ascii value for non-doubled non-digit isn\'t allowed', ->
+  xit "using ascii value for non-doubled non-digit isn't allowed", ->
     luhn = new Luhn('055b 444 285')
     expect(luhn.valid()).toBe false
 
-  xit 'using ascii value for doubled non-digit isn\'t allowed', ->
+  xit "using ascii value for doubled non-digit isn't allowed", ->
     luhn = new Luhn(':9')
     expect(luhn.valid()).toBe false
 
-  xit 'non-numeric, non-space char in the middle with a sum that\'s divisible by 10 isn\'t allowed', ->
+  xit "non-numeric, non-space char in the middle with a sum that's divisible by 10 isn't allowed", ->
     luhn = new Luhn('59%59')
     expect(luhn.valid()).toBe false


### PR DESCRIPTION
Removed escaped apostrophes after fixing test runner: https://github.com/exercism/coffeescript-test-runner/pull/57