### PR TITLE
Fix syntax error in matching-brackets example

### DIFF
--- a/exercises/practice/matching-brackets/.meta/example.coffee
+++ b/exercises/practice/matching-brackets/.meta/example.coffee
@@ -1,5 +1,5 @@
 class MatchingBrackets
-  @isPaired (value) ->
+  @isPaired: (value) ->
     stack = []
     for char in value
       if char in ['[', '{', '(']


### PR DESCRIPTION
This solution passed the CI but not in the web editor which complained isPaired isn't a function. We should use the test runner image in the CI to make sure the examples work as expected. That'll be a follow-up PR later.