### PR TITLE
meetup exercise: off-by-one error

### DIFF
--- a/exercises/practice/meetup/.meta/example.coffee
+++ b/exercises/practice/meetup/.meta/example.coffee
@@ -33,7 +33,7 @@ meetup = ({year, month, week, dayofweek}) ->
   loop
     d = date.getDate()
     if date.getDay() == dayofweek and d >= week
-      return Date.UTC date.getFullYear(), date.getMonth() + 1, d
+      return new Date date.getFullYear(), date.getMonth(), d
     date.setDate d + 1
 
 module.exports = {Weeks, Weekdays, meetup}

--- a/exercises/practice/meetup/meetup.spec.coffee
+++ b/exercises/practice/meetup/meetup.spec.coffee
@@ -1,5 +1,13 @@
 {meetup, Weeks, Weekdays} = require './meetup'
 
+###
+Note: the month value of a JavaScript Date object is a "month index".
+It is zero-based: 0 = January, 11 = December.
+Ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date#monthindex
+
+In the input object sent to the meetup function, the month value is 1-based.
+###
+
 describe 'Meetup', ->
   it "when teenth Monday is the 13th, the first day of the teenth week", ->
     input = {
@@ -8,7 +16,7 @@ describe 'Meetup', ->
       week: Weeks.Teenth,
       dayofweek: Weekdays.Monday
     }
-    expected = Date.UTC 2013, 5, 13
+    expected = new Date 2013, 5 - 1, 13
     expect(meetup input).toEqual expected
 
   xit "when teenth Monday is the 19th, the last day of the teenth week", ->
@@ -18,7 +26,7 @@ describe 'Meetup', ->
       week: Weeks.Teenth,
       dayofweek: Weekdays.Monday
     }
-    expected = Date.UTC 2013, 8, 19
+    expected = new Date 2013, 8 - 1, 19
     expect(meetup input).toEqual expected
 
   xit "when teenth Monday is some day in the middle of the teenth week", ->
@@ -28,7 +36,7 @@ describe 'Meetup', ->
       week: Weeks.Teenth,
       dayofweek: Weekdays.Monday
     }
-    expected = Date.UTC 2013, 9, 16
+    expected = new Date 2013, 9 - 1, 16
     expect(meetup input).toEqual expected
 
   xit "when teenth Tuesday is the 19th, the last day of the teenth week", ->
@@ -38,7 +46,7 @@ describe 'Meetup', ->
       week: Weeks.Teenth,
       dayofweek: Weekdays.Tuesday
     }
-    expected = Date.UTC 2013, 3, 19
+    expected = new Date 2013, 3 - 1, 19
     expect(meetup input).toEqual expected
 
   xit "when teenth Tuesday is some day in the middle of the teenth week", ->
@@ -48,7 +56,7 @@ describe 'Meetup', ->
       week: Weeks.Teenth,
       dayofweek: Weekdays.Tuesday
     }
-    expected = Date.UTC 2013, 4, 16
+    expected = new Date 2013, 4 - 1, 16
     expect(meetup input).toEqual expected
 
   xit "when teenth Tuesday is the 13th, the first day of the teenth week", ->
@@ -58,7 +66,7 @@ describe 'Meetup', ->
       week: Weeks.Teenth,
       dayofweek: Weekdays.Tuesday
     }
-    expected = Date.UTC 2013, 8, 13
+    expected = new Date 2013, 8 - 1, 13
     expect(meetup input).toEqual expected
 
   xit "when teenth Wednesday is some day in the middle of the teenth week", ->
@@ -68,7 +76,7 @@ describe 'Meetup', ->
       week: Weeks.Teenth,
       dayofweek: Weekdays.Wednesday
     }
-    expected = Date.UTC 2013, 1, 16
+    expected = new Date 2013, 1 - 1, 16
     expect(meetup input).toEqual expected
 
   xit "when teenth Wednesday is the 13th, the first day of the teenth week", ->
@@ -78,7 +86,7 @@ describe 'Meetup', ->
       week: Weeks.Teenth,
       dayofweek: Weekdays.Wednesday
     }
-    expected = Date.UTC 2013, 2, 13
+    expected = new Date 2013, 2 - 1, 13
     expect(meetup input).toEqual expected
 
   xit "when teenth Wednesday is the 19th, the last day of the teenth week", ->
@@ -88,7 +96,7 @@ describe 'Meetup', ->
       week: Weeks.Teenth,
       dayofweek: Weekdays.Wednesday
     }
-    expected = Date.UTC 2013, 6, 19
+    expected = new Date 2013, 6 - 1, 19
     expect(meetup input).toEqual expected
 
   xit "when teenth Thursday is some day in the middle of the teenth week", ->
@@ -98,7 +106,7 @@ describe 'Meetup', ->
       week: Weeks.Teenth,
       dayofweek: Weekdays.Thursday
     }
-    expected = Date.UTC 2013, 5, 16
+    expected = new Date 2013, 5 - 1, 16
     expect(meetup input).toEqual expected
 
   xit "when teenth Thursday is the 13th, the first day of the teenth week", ->
@@ -108,7 +116,7 @@ describe 'Meetup', ->
       week: Weeks.Teenth,
       dayofweek: Weekdays.Thursday
     }
-    expected = Date.UTC 2013, 6, 13
+    expected = new Date 2013, 6 - 1, 13
     expect(meetup input).toEqual expected
 
   xit "when teenth Thursday is the 19th, the last day of the teenth week", ->
@@ -118,7 +126,7 @@ describe 'Meetup', ->
       week: Weeks.Teenth,
       dayofweek: Weekdays.Thursday
     }
-    expected = Date.UTC 2013, 9, 19
+    expected = new Date 2013, 9 - 1, 19
     expect(meetup input).toEqual expected
 
   xit "when teenth Friday is the 19th, the last day of the teenth week", ->
@@ -128,7 +136,7 @@ describe 'Meetup', ->
       week: Weeks.Teenth,
       dayofweek: Weekdays.Friday
     }
-    expected = Date.UTC 2013, 4, 19
+    expected = new Date 2013, 4 - 1, 19
     expect(meetup input).toEqual expected
 
   xit "when teenth Friday is some day in the middle of the teenth week", ->
@@ -138,7 +146,7 @@ describe 'Meetup', ->
       week: Weeks.Teenth,
       dayofweek: Weekdays.Friday
     }
-    expected = Date.UTC 2013, 8, 16
+    expected = new Date 2013, 8 - 1, 16
     expect(meetup input).toEqual expected
 
   xit "when teenth Friday is the 13th, the first day of the teenth week", ->
@@ -148,7 +156,7 @@ describe 'Meetup', ->
       week: Weeks.Teenth,
       dayofweek: Weekdays.Friday
     }
-    expected = Date.UTC 2013, 9, 13
+    expected = new Date 2013, 9 - 1, 13
     expect(meetup input).toEqual expected
 
   xit "when teenth Saturday is some day in the middle of the teenth week", ->
@@ -158,7 +166,7 @@ describe 'Meetup', ->
       week: Weeks.Teenth,
       dayofweek: Weekdays.Saturday
     }
-    expected = Date.UTC 2013, 2, 16
+    expected = new Date 2013, 2 - 1, 16
     expect(meetup input).toEqual expected
 
   xit "when teenth Saturday is the 13th, the first day of the teenth week", ->
@@ -168,7 +176,7 @@ describe 'Meetup', ->
       week: Weeks.Teenth,
       dayofweek: Weekdays.Saturday
     }
-    expected = Date.UTC 2013, 4, 13
+    expected = new Date 2013, 4 - 1, 13
     expect(meetup input).toEqual expected
 
   xit "when teenth Saturday is the 19th, the last day of the teenth week", ->
@@ -178,7 +186,7 @@ describe 'Meetup', ->
       week: Weeks.Teenth,
       dayofweek: Weekdays.Saturday
     }
-    expected = Date.UTC 2013, 10, 19
+    expected = new Date 2013, 10 - 1, 19
     expect(meetup input).toEqual expected
 
   xit "when teenth Sunday is the 19th, the last day of the teenth week", ->
@@ -188,7 +196,7 @@ describe 'Meetup', ->
       week: Weeks.Teenth,
       dayofweek: Weekdays.Sunday
     }
-    expected = Date.UTC 2013, 5, 19
+    expected = new Date 2013, 5 - 1, 19
     expect(meetup input).toEqual expected
 
   xit "when teenth Sunday is some day in the middle of the teenth week", ->
@@ -198,7 +206,7 @@ describe 'Meetup', ->
       week: Weeks.Teenth,
       dayofweek: Weekdays.Sunday
     }
-    expected = Date.UTC 2013, 6, 16
+    expected = new Date 2013, 6 - 1, 16
     expect(meetup input).toEqual expected
 
   xit "when teenth Sunday is the 13th, the first day of the teenth week", ->
@@ -208,7 +216,7 @@ describe 'Meetup', ->
       week: Weeks.Teenth,
       dayofweek: Weekdays.Sunday
     }
-    expected = Date.UTC 2013, 10, 13
+    expected = new Date 2013, 10 - 1, 13
     expect(meetup input).toEqual expected
 
   xit "when first Monday is some day in the middle of the first week", ->
@@ -218,7 +226,7 @@ describe 'Meetup', ->
       week: Weeks.First,
       dayofweek: Weekdays.Monday
     }
-    expected = Date.UTC 2013, 3, 4
+    expected = new Date 2013, 3 - 1, 4
     expect(meetup input).toEqual expected
 
   xit "when first Monday is the 1st, the first day of the first week", ->
@@ -228,7 +236,7 @@ describe 'Meetup', ->
       week: Weeks.First,
       dayofweek: Weekdays.Monday
     }
-    expected = Date.UTC 2013, 4, 1
+    expected = new Date 2013, 4 - 1, 1
     expect(meetup input).toEqual expected
 
   xit "when first Tuesday is the 7th, the last day of the first week", ->
@@ -238,7 +246,7 @@ describe 'Meetup', ->
       week: Weeks.First,
       dayofweek: Weekdays.Tuesday
     }
-    expected = Date.UTC 2013, 5, 7
+    expected = new Date 2013, 5 - 1, 7
     expect(meetup input).toEqual expected
 
   xit "when first Tuesday is some day in the middle of the first week", ->
@@ -248,7 +256,7 @@ describe 'Meetup', ->
       week: Weeks.First,
       dayofweek: Weekdays.Tuesday
     }
-    expected = Date.UTC 2013, 6, 4
+    expected = new Date 2013, 6 - 1, 4
     expect(meetup input).toEqual expected
 
   xit "when first Wednesday is some day in the middle of the first week", ->
@@ -258,7 +266,7 @@ describe 'Meetup', ->
       week: Weeks.First,
       dayofweek: Weekdays.Wednesday
     }
-    expected = Date.UTC 2013, 7, 3
+    expected = new Date 2013, 7 - 1, 3
     expect(meetup input).toEqual expected
 
   xit "when first Wednesday is the 7th, the last day of the first week", ->
@@ -268,7 +276,7 @@ describe 'Meetup', ->
       week: Weeks.First,
       dayofweek: Weekdays.Wednesday
     }
-    expected = Date.UTC 2013, 8, 7
+    expected = new Date 2013, 8 - 1, 7
     expect(meetup input).toEqual expected
 
   xit "when first Thursday is some day in the middle of the first week", ->
@@ -278,7 +286,7 @@ describe 'Meetup', ->
       week: Weeks.First,
       dayofweek: Weekdays.Thursday
     }
-    expected = Date.UTC 2013, 9, 5
+    expected = new Date 2013, 9 - 1, 5
     expect(meetup input).toEqual expected
 
   xit "when first Thursday is another day in the middle of the first week", ->
@@ -288,7 +296,7 @@ describe 'Meetup', ->
       week: Weeks.First,
       dayofweek: Weekdays.Thursday
     }
-    expected = Date.UTC 2013, 10, 3
+    expected = new Date 2013, 10 - 1, 3
     expect(meetup input).toEqual expected
 
   xit "when first Friday is the 1st, the first day of the first week", ->
@@ -298,7 +306,7 @@ describe 'Meetup', ->
       week: Weeks.First,
       dayofweek: Weekdays.Friday
     }
-    expected = Date.UTC 2013, 11, 1
+    expected = new Date 2013, 11 - 1, 1
     expect(meetup input).toEqual expected
 
   xit "when first Friday is some day in the middle of the first week", ->
@@ -308,7 +316,7 @@ describe 'Meetup', ->
       week: Weeks.First,
       dayofweek: Weekdays.Friday
     }
-    expected = Date.UTC 2013, 12, 6
+    expected = new Date 2013, 12 - 1, 6
     expect(meetup input).toEqual expected
 
   xit "when first Saturday is some day in the middle of the first week", ->
@@ -318,7 +326,7 @@ describe 'Meetup', ->
       week: Weeks.First,
       dayofweek: Weekdays.Saturday
     }
-    expected = Date.UTC 2013, 1, 5
+    expected = new Date 2013, 1 - 1, 5
     expect(meetup input).toEqual expected
 
   xit "when first Saturday is another day in the middle of the first week", ->
@@ -328,7 +336,7 @@ describe 'Meetup', ->
       week: Weeks.First,
       dayofweek: Weekdays.Saturday
     }
-    expected = Date.UTC 2013, 2, 2
+    expected = new Date 2013, 2 - 1, 2
     expect(meetup input).toEqual expected
 
   xit "when first Sunday is some day in the middle of the first week", ->
@@ -338,7 +346,7 @@ describe 'Meetup', ->
       week: Weeks.First,
       dayofweek: Weekdays.Sunday
     }
-    expected = Date.UTC 2013, 3, 3
+    expected = new Date 2013, 3 - 1, 3
     expect(meetup input).toEqual expected
 
   xit "when first Sunday is the 7th, the last day of the first week", ->
@@ -348,7 +356,7 @@ describe 'Meetup', ->
       week: Weeks.First,
       dayofweek: Weekdays.Sunday
     }
-    expected = Date.UTC 2013, 4, 7
+    expected = new Date 2013, 4 - 1, 7
     expect(meetup input).toEqual expected
 
   xit "when second Monday is some day in the middle of the second week", ->
@@ -358,7 +366,7 @@ describe 'Meetup', ->
       week: Weeks.Second,
       dayofweek: Weekdays.Monday
     }
-    expected = Date.UTC 2013, 3, 11
+    expected = new Date 2013, 3 - 1, 11
     expect(meetup input).toEqual expected
 
   xit "when second Monday is the 8th, the first day of the second week", ->
@@ -368,7 +376,7 @@ describe 'Meetup', ->
       week: Weeks.Second,
       dayofweek: Weekdays.Monday
     }
-    expected = Date.UTC 2013, 4, 8
+    expected = new Date 2013, 4 - 1, 8
     expect(meetup input).toEqual expected
 
   xit "when second Tuesday is the 14th, the last day of the second week", ->
@@ -378,7 +386,7 @@ describe 'Meetup', ->
       week: Weeks.Second,
       dayofweek: Weekdays.Tuesday
     }
-    expected = Date.UTC 2013, 5, 14
+    expected = new Date 2013, 5 - 1, 14
     expect(meetup input).toEqual expected
 
   xit "when second Tuesday is some day in the middle of the second week", ->
@@ -388,7 +396,7 @@ describe 'Meetup', ->
       week: Weeks.Second,
       dayofweek: Weekdays.Tuesday
     }
-    expected = Date.UTC 2013, 6, 11
+    expected = new Date 2013, 6 - 1, 11
     expect(meetup input).toEqual expected
 
   xit "when second Wednesday is some day in the middle of the second week", ->
@@ -398,7 +406,7 @@ describe 'Meetup', ->
       week: Weeks.Second,
       dayofweek: Weekdays.Wednesday
     }
-    expected = Date.UTC 2013, 7, 10
+    expected = new Date 2013, 7 - 1, 10
     expect(meetup input).toEqual expected
 
   xit "when second Wednesday is the 14th, the last day of the second week", ->
@@ -408,7 +416,7 @@ describe 'Meetup', ->
       week: Weeks.Second,
       dayofweek: Weekdays.Wednesday
     }
-    expected = Date.UTC 2013, 8, 14
+    expected = new Date 2013, 8 - 1, 14
     expect(meetup input).toEqual expected
 
   xit "when second Thursday is some day in the middle of the second week", ->
@@ -418,7 +426,7 @@ describe 'Meetup', ->
       week: Weeks.Second,
       dayofweek: Weekdays.Thursday
     }
-    expected = Date.UTC 2013, 9, 12
+    expected = new Date 2013, 9 - 1, 12
     expect(meetup input).toEqual expected
 
   xit "when second Thursday is another day in the middle of the second week", ->
@@ -428,7 +436,7 @@ describe 'Meetup', ->
       week: Weeks.Second,
       dayofweek: Weekdays.Thursday
     }
-    expected = Date.UTC 2013, 10, 10
+    expected = new Date 2013, 10 - 1, 10
     expect(meetup input).toEqual expected
 
   xit "when second Friday is the 8th, the first day of the second week", ->
@@ -438,7 +446,7 @@ describe 'Meetup', ->
       week: Weeks.Second,
       dayofweek: Weekdays.Friday
     }
-    expected = Date.UTC 2013, 11, 8
+    expected = new Date 2013, 11 - 1, 8
     expect(meetup input).toEqual expected
 
   xit "when second Friday is some day in the middle of the second week", ->
@@ -448,7 +456,7 @@ describe 'Meetup', ->
       week: Weeks.Second,
       dayofweek: Weekdays.Friday
     }
-    expected = Date.UTC 2013, 12, 13
+    expected = new Date 2013, 12 - 1, 13
     expect(meetup input).toEqual expected
 
   xit "when second Saturday is some day in the middle of the second week", ->
@@ -458,7 +466,7 @@ describe 'Meetup', ->
       week: Weeks.Second,
       dayofweek: Weekdays.Saturday
     }
-    expected = Date.UTC 2013, 1, 12
+    expected = new Date 2013, 1 - 1, 12
     expect(meetup input).toEqual expected
 
   xit "when second Saturday is another day in the middle of the second week", ->
@@ -468,7 +476,7 @@ describe 'Meetup', ->
       week: Weeks.Second,
       dayofweek: Weekdays.Saturday
     }
-    expected = Date.UTC 2013, 2, 9
+    expected = new Date 2013, 2 - 1, 9
     expect(meetup input).toEqual expected
 
   xit "when second Sunday is some day in the middle of the second week", ->
@@ -478,7 +486,7 @@ describe 'Meetup', ->
       week: Weeks.Second,
       dayofweek: Weekdays.Sunday
     }
-    expected = Date.UTC 2013, 3, 10
+    expected = new Date 2013, 3 - 1, 10
     expect(meetup input).toEqual expected
 
   xit "when second Sunday is the 14th, the last day of the second week", ->
@@ -488,7 +496,7 @@ describe 'Meetup', ->
       week: Weeks.Second,
       dayofweek: Weekdays.Sunday
     }
-    expected = Date.UTC 2013, 4, 14
+    expected = new Date 2013, 4 - 1, 14
     expect(meetup input).toEqual expected
 
   xit "when third Monday is some day in the middle of the third week", ->
@@ -498,7 +506,7 @@ describe 'Meetup', ->
       week: Weeks.Third,
       dayofweek: Weekdays.Monday
     }
-    expected = Date.UTC 2013, 3, 18
+    expected = new Date 2013, 3 - 1, 18
     expect(meetup input).toEqual expected
 
   xit "when third Monday is the 15th, the first day of the third week", ->
@@ -508,7 +516,7 @@ describe 'Meetup', ->
       week: Weeks.Third,
       dayofweek: Weekdays.Monday
     }
-    expected = Date.UTC 2013, 4, 15
+    expected = new Date 2013, 4 - 1, 15
     expect(meetup input).toEqual expected
 
   xit "when third Tuesday is the 21st, the last day of the third week", ->
@@ -518,7 +526,7 @@ describe 'Meetup', ->
       week: Weeks.Third,
       dayofweek: Weekdays.Tuesday
     }
-    expected = Date.UTC 2013, 5, 21
+    expected = new Date 2013, 5 - 1, 21
     expect(meetup input).toEqual expected
 
   xit "when third Tuesday is some day in the middle of the third week", ->
@@ -528,7 +536,7 @@ describe 'Meetup', ->
       week: Weeks.Third,
       dayofweek: Weekdays.Tuesday
     }
-    expected = Date.UTC 2013, 6, 18
+    expected = new Date 2013, 6 - 1, 18
     expect(meetup input).toEqual expected
 
   xit "when third Wednesday is some day in the middle of the third week", ->
@@ -538,7 +546,7 @@ describe 'Meetup', ->
       week: Weeks.Third,
       dayofweek: Weekdays.Wednesday
     }
-    expected = Date.UTC 2013, 7, 17
+    expected = new Date 2013, 7 - 1, 17
     expect(meetup input).toEqual expected
 
   xit "when third Wednesday is the 21st, the last day of the third week", ->
@@ -548,7 +556,7 @@ describe 'Meetup', ->
       week: Weeks.Third,
       dayofweek: Weekdays.Wednesday
     }
-    expected = Date.UTC 2013, 8, 21
+    expected = new Date 2013, 8 - 1, 21
     expect(meetup input).toEqual expected
 
   xit "when third Thursday is some day in the middle of the third week", ->
@@ -558,7 +566,7 @@ describe 'Meetup', ->
       week: Weeks.Third,
       dayofweek: Weekdays.Thursday
     }
-    expected = Date.UTC 2013, 9, 19
+    expected = new Date 2013, 9 - 1, 19
     expect(meetup input).toEqual expected
 
   xit "when third Thursday is another day in the middle of the third week", ->
@@ -568,7 +576,7 @@ describe 'Meetup', ->
       week: Weeks.Third,
       dayofweek: Weekdays.Thursday
     }
-    expected = Date.UTC 2013, 10, 17
+    expected = new Date 2013, 10 - 1, 17
     expect(meetup input).toEqual expected
 
   xit "when third Friday is the 15th, the first day of the third week", ->
@@ -578,7 +586,7 @@ describe 'Meetup', ->
       week: Weeks.Third,
       dayofweek: Weekdays.Friday
     }
-    expected = Date.UTC 2013, 11, 15
+    expected = new Date 2013, 11 - 1, 15
     expect(meetup input).toEqual expected
 
   xit "when third Friday is some day in the middle of the third week", ->
@@ -588,7 +596,7 @@ describe 'Meetup', ->
       week: Weeks.Third,
       dayofweek: Weekdays.Friday
     }
-    expected = Date.UTC 2013, 12, 20
+    expected = new Date 2013, 12 - 1, 20
     expect(meetup input).toEqual expected
 
   xit "when third Saturday is some day in the middle of the third week", ->
@@ -598,7 +606,7 @@ describe 'Meetup', ->
       week: Weeks.Third,
       dayofweek: Weekdays.Saturday
     }
-    expected = Date.UTC 2013, 1, 19
+    expected = new Date 2013, 1 - 1, 19
     expect(meetup input).toEqual expected
 
   xit "when third Saturday is another day in the middle of the third week", ->
@@ -608,7 +616,7 @@ describe 'Meetup', ->
       week: Weeks.Third,
       dayofweek: Weekdays.Saturday
     }
-    expected = Date.UTC 2013, 2, 16
+    expected = new Date 2013, 2 - 1, 16
     expect(meetup input).toEqual expected
 
   xit "when third Sunday is some day in the middle of the third week", ->
@@ -618,7 +626,7 @@ describe 'Meetup', ->
       week: Weeks.Third,
       dayofweek: Weekdays.Sunday
     }
-    expected = Date.UTC 2013, 3, 17
+    expected = new Date 2013, 3 - 1, 17
     expect(meetup input).toEqual expected
 
   xit "when third Sunday is the 21st, the last day of the third week", ->
@@ -628,7 +636,7 @@ describe 'Meetup', ->
       week: Weeks.Third,
       dayofweek: Weekdays.Sunday
     }
-    expected = Date.UTC 2013, 4, 21
+    expected = new Date 2013, 4 - 1, 21
     expect(meetup input).toEqual expected
 
   xit "when fourth Monday is some day in the middle of the fourth week", ->
@@ -638,7 +646,7 @@ describe 'Meetup', ->
       week: Weeks.Fourth,
       dayofweek: Weekdays.Monday
     }
-    expected = Date.UTC 2013, 3, 25
+    expected = new Date 2013, 3 - 1, 25
     expect(meetup input).toEqual expected
 
   xit "when fourth Monday is the 22nd, the first day of the fourth week", ->
@@ -648,7 +656,7 @@ describe 'Meetup', ->
       week: Weeks.Fourth,
       dayofweek: Weekdays.Monday
     }
-    expected = Date.UTC 2013, 4, 22
+    expected = new Date 2013, 4 - 1, 22
     expect(meetup input).toEqual expected
 
   xit "when fourth Tuesday is the 28th, the last day of the fourth week", ->
@@ -658,7 +666,7 @@ describe 'Meetup', ->
       week: Weeks.Fourth,
       dayofweek: Weekdays.Tuesday
     }
-    expected = Date.UTC 2013, 5, 28
+    expected = new Date 2013, 5 - 1, 28
     expect(meetup input).toEqual expected
 
   xit "when fourth Tuesday is some day in the middle of the fourth week", ->
@@ -668,7 +676,7 @@ describe 'Meetup', ->
       week: Weeks.Fourth,
       dayofweek: Weekdays.Tuesday
     }
-    expected = Date.UTC 2013, 6, 25
+    expected = new Date 2013, 6 - 1, 25
     expect(meetup input).toEqual expected
 
   xit "when fourth Wednesday is some day in the middle of the fourth week", ->
@@ -678,7 +686,7 @@ describe 'Meetup', ->
       week: Weeks.Fourth,
       dayofweek: Weekdays.Wednesday
     }
-    expected = Date.UTC 2013, 7, 24
+    expected = new Date 2013, 7 - 1, 24
     expect(meetup input).toEqual expected
 
   xit "when fourth Wednesday is the 28th, the last day of the fourth week", ->
@@ -688,7 +696,7 @@ describe 'Meetup', ->
       week: Weeks.Fourth,
       dayofweek: Weekdays.Wednesday
     }
-    expected = Date.UTC 2013, 8, 28
+    expected = new Date 2013, 8 - 1, 28
     expect(meetup input).toEqual expected
 
   xit "when fourth Thursday is some day in the middle of the fourth week", ->
@@ -698,7 +706,7 @@ describe 'Meetup', ->
       week: Weeks.Fourth,
       dayofweek: Weekdays.Thursday
     }
-    expected = Date.UTC 2013, 9, 26
+    expected = new Date 2013, 9 - 1, 26
     expect(meetup input).toEqual expected
 
   xit "when fourth Thursday is another day in the middle of the fourth week", ->
@@ -708,7 +716,7 @@ describe 'Meetup', ->
       week: Weeks.Fourth,
       dayofweek: Weekdays.Thursday
     }
-    expected = Date.UTC 2013, 10, 24
+    expected = new Date 2013, 10 - 1, 24
     expect(meetup input).toEqual expected
 
   xit "when fourth Friday is the 22nd, the first day of the fourth week", ->
@@ -718,7 +726,7 @@ describe 'Meetup', ->
       week: Weeks.Fourth,
       dayofweek: Weekdays.Friday
     }
-    expected = Date.UTC 2013, 11, 22
+    expected = new Date 2013, 11 - 1, 22
     expect(meetup input).toEqual expected
 
   xit "when fourth Friday is some day in the middle of the fourth week", ->
@@ -728,7 +736,7 @@ describe 'Meetup', ->
       week: Weeks.Fourth,
       dayofweek: Weekdays.Friday
     }
-    expected = Date.UTC 2013, 12, 27
+    expected = new Date 2013, 12 - 1, 27
     expect(meetup input).toEqual expected
 
   xit "when fourth Saturday is some day in the middle of the fourth week", ->
@@ -738,7 +746,7 @@ describe 'Meetup', ->
       week: Weeks.Fourth,
       dayofweek: Weekdays.Saturday
     }
-    expected = Date.UTC 2013, 1, 26
+    expected = new Date 2013, 1 - 1, 26
     expect(meetup input).toEqual expected
 
   xit "when fourth Saturday is another day in the middle of the fourth week", ->
@@ -748,7 +756,7 @@ describe 'Meetup', ->
       week: Weeks.Fourth,
       dayofweek: Weekdays.Saturday
     }
-    expected = Date.UTC 2013, 2, 23
+    expected = new Date 2013, 2 - 1, 23
     expect(meetup input).toEqual expected
 
   xit "when fourth Sunday is some day in the middle of the fourth week", ->
@@ -758,7 +766,7 @@ describe 'Meetup', ->
       week: Weeks.Fourth,
       dayofweek: Weekdays.Sunday
     }
-    expected = Date.UTC 2013, 3, 24
+    expected = new Date 2013, 3 - 1, 24
     expect(meetup input).toEqual expected
 
   xit "when fourth Sunday is the 28th, the last day of the fourth week", ->
@@ -768,7 +776,7 @@ describe 'Meetup', ->
       week: Weeks.Fourth,
       dayofweek: Weekdays.Sunday
     }
-    expected = Date.UTC 2013, 4, 28
+    expected = new Date 2013, 4 - 1, 28
     expect(meetup input).toEqual expected
 
   xit "last Monday in a month with four Mondays", ->
@@ -778,7 +786,7 @@ describe 'Meetup', ->
       week: Weeks.Last,
       dayofweek: Weekdays.Monday
     }
-    expected = Date.UTC 2013, 3, 25
+    expected = new Date 2013, 3 - 1, 25
     expect(meetup input).toEqual expected
 
   xit "last Monday in a month with five Mondays", ->
@@ -788,7 +796,7 @@ describe 'Meetup', ->
       week: Weeks.Last,
       dayofweek: Weekdays.Monday
     }
-    expected = Date.UTC 2013, 4, 29
+    expected = new Date 2013, 4 - 1, 29
     expect(meetup input).toEqual expected
 
   xit "last Tuesday in a month with four Tuesdays", ->
@@ -798,7 +806,7 @@ describe 'Meetup', ->
       week: Weeks.Last,
       dayofweek: Weekdays.Tuesday
     }
-    expected = Date.UTC 2013, 5, 28
+    expected = new Date 2013, 5 - 1, 28
     expect(meetup input).toEqual expected
 
   xit "last Tuesday in another month with four Tuesdays", ->
@@ -808,7 +816,7 @@ describe 'Meetup', ->
       week: Weeks.Last,
       dayofweek: Weekdays.Tuesday
     }
-    expected = Date.UTC 2013, 6, 25
+    expected = new Date 2013, 6 - 1, 25
     expect(meetup input).toEqual expected
 
   xit "last Wednesday in a month with five Wednesdays", ->
@@ -818,7 +826,7 @@ describe 'Meetup', ->
       week: Weeks.Last,
       dayofweek: Weekdays.Wednesday
     }
-    expected = Date.UTC 2013, 7, 31
+    expected = new Date 2013, 7 - 1, 31
     expect(meetup input).toEqual expected
 
   xit "last Wednesday in a month with four Wednesdays", ->
@@ -828,7 +836,7 @@ describe 'Meetup', ->
       week: Weeks.Last,
       dayofweek: Weekdays.Wednesday
     }
-    expected = Date.UTC 2013, 8, 28
+    expected = new Date 2013, 8 - 1, 28
     expect(meetup input).toEqual expected
 
   xit "last Thursday in a month with four Thursdays", ->
@@ -838,7 +846,7 @@ describe 'Meetup', ->
       week: Weeks.Last,
       dayofweek: Weekdays.Thursday
     }
-    expected = Date.UTC 2013, 9, 26
+    expected = new Date 2013, 9 - 1, 26
     expect(meetup input).toEqual expected
 
   xit "last Thursday in a month with five Thursdays", ->
@@ -848,7 +856,7 @@ describe 'Meetup', ->
       week: Weeks.Last,
       dayofweek: Weekdays.Thursday
     }
-    expected = Date.UTC 2013, 10, 31
+    expected = new Date 2013, 10 - 1, 31
     expect(meetup input).toEqual expected
 
   xit "last Friday in a month with five Fridays", ->
@@ -858,7 +866,7 @@ describe 'Meetup', ->
       week: Weeks.Last,
       dayofweek: Weekdays.Friday
     }
-    expected = Date.UTC 2013, 11, 29
+    expected = new Date 2013, 11 - 1, 29
     expect(meetup input).toEqual expected
 
   xit "last Friday in a month with four Fridays", ->
@@ -868,7 +876,7 @@ describe 'Meetup', ->
       week: Weeks.Last,
       dayofweek: Weekdays.Friday
     }
-    expected = Date.UTC 2013, 12, 27
+    expected = new Date 2013, 12 - 1, 27
     expect(meetup input).toEqual expected
 
   xit "last Saturday in a month with four Saturdays", ->
@@ -878,7 +886,7 @@ describe 'Meetup', ->
       week: Weeks.Last,
       dayofweek: Weekdays.Saturday
     }
-    expected = Date.UTC 2013, 1, 26
+    expected = new Date 2013, 1 - 1, 26
     expect(meetup input).toEqual expected
 
   xit "last Saturday in another month with four Saturdays", ->
@@ -888,7 +896,7 @@ describe 'Meetup', ->
       week: Weeks.Last,
       dayofweek: Weekdays.Saturday
     }
-    expected = Date.UTC 2013, 2, 23
+    expected = new Date 2013, 2 - 1, 23
     expect(meetup input).toEqual expected
 
   xit "last Sunday in a month with five Sundays", ->
@@ -898,7 +906,7 @@ describe 'Meetup', ->
       week: Weeks.Last,
       dayofweek: Weekdays.Sunday
     }
-    expected = Date.UTC 2013, 3, 31
+    expected = new Date 2013, 3 - 1, 31
     expect(meetup input).toEqual expected
 
   xit "last Sunday in a month with four Sundays", ->
@@ -908,7 +916,7 @@ describe 'Meetup', ->
       week: Weeks.Last,
       dayofweek: Weekdays.Sunday
     }
-    expected = Date.UTC 2013, 4, 28
+    expected = new Date 2013, 4 - 1, 28
     expect(meetup input).toEqual expected
 
   xit "when last Wednesday in February in a leap year is the 29th", ->
@@ -918,7 +926,7 @@ describe 'Meetup', ->
       week: Weeks.Last,
       dayofweek: Weekdays.Wednesday
     }
-    expected = Date.UTC 2012, 2, 29
+    expected = new Date 2012, 2 - 1, 29
     expect(meetup input).toEqual expected
 
   xit "last Wednesday in December that is also the last day of the year", ->
@@ -928,7 +936,7 @@ describe 'Meetup', ->
       week: Weeks.Last,
       dayofweek: Weekdays.Wednesday
     }
-    expected = Date.UTC 2014, 12, 31
+    expected = new Date 2014, 12 - 1, 31
     expect(meetup input).toEqual expected
 
   xit "when last Sunday in February in a non-leap year is not the 29th", ->
@@ -938,7 +946,7 @@ describe 'Meetup', ->
       week: Weeks.Last,
       dayofweek: Weekdays.Sunday
     }
-    expected = Date.UTC 2015, 2, 22
+    expected = new Date 2015, 2 - 1, 22
     expect(meetup input).toEqual expected
 
   xit "when first Friday is the 7th, the last day of the first week", ->
@@ -948,5 +956,5 @@ describe 'Meetup', ->
       week: Weeks.First,
       dayofweek: Weekdays.Friday
     }
-    expected = Date.UTC 2012, 12, 7
+    expected = new Date 2012, 12 - 1, 7
     expect(meetup input).toEqual expected


### PR DESCRIPTION
For Date.UTC, the month value is a _month index_. I was not decrementing by one.

Also, changed `Date.UTC` to `new Date` to avoid any timezone related issues.

attn: @BNAndras 