### PR TITLE
Deprecate `binary`, `hexadecimal`, and `trinary`

### DIFF
--- a/config.json
+++ b/config.json
@@ -101,6 +101,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
+        "status": "deprecated",
         "topics": [
           "integers",
           "math",
@@ -221,6 +222,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
+        "status": "deprecated",
         "topics": [
           "integers",
           "math",
@@ -536,6 +538,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
+        "status": "deprecated",
         "topics": [
           "integers",
           "math",


### PR DESCRIPTION
Binary, Hexadecimal, and Trinary are all deprecated in the upstream problem-specifications repo in favor of All Your Base. That exercise is already implemented so I can go ahead and deprecate these.