### PR TITLE
Typo in method name in custom-set stub

### DIFF
--- a/exercises/practice/custom-set/custom-set.coffee
+++ b/exercises/practice/custom-set/custom-set.coffee
@@ -9,7 +9,7 @@ class CustomSet
 
   disjoint: (other) ->
 
-  equall: (other) ->
+  equal: (other) ->
 
   add: (value) ->
 


### PR DESCRIPTION
`equall` -> `equal`