### PR TITLE
Track access count in binary-search

### DIFF
--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -11,6 +11,9 @@
     ],
     "example": [
       ".meta/example.coffee"
+    ],
+    "editor": [
+      "traced-array.coffee"
     ]
   },
   "blurb": "Implement a binary search algorithm.",

--- a/exercises/practice/binary-search/.meta/example.coffee
+++ b/exercises/practice/binary-search/.meta/example.coffee
@@ -1,12 +1,12 @@
 class BinarySearch
-  constructor: (@values) ->
+  constructor: (@array) ->
 
   find: (value) ->
     start = 0
-    end = @values.length - 1
+    end = @array.length - 1
     while start <= end
         mid = (start + end) // 2
-        item = @values[mid]
+        item = @array.get mid
         if value == item
             return mid
         else if value <= item

--- a/exercises/practice/binary-search/binary-search.coffee
+++ b/exercises/practice/binary-search/binary-search.coffee
@@ -1,6 +1,19 @@
 class BinarySearch
-  constructor: (values) ->
+  constructor: (@array) ->
 
   find: (value) ->
+    start = 0
+    end = @array.length - 1
+    while start <= end
+        mid = (start + end) // 2
+        item = @array.get mid
+        if value == item
+            return mid
+        else if value <= item
+            end = mid - 1
+        else if value >= item
+            start = mid + 1
+
+    throw new Error 'value not in array'
 
 module.exports = BinarySearch

--- a/exercises/practice/binary-search/binary-search.coffee
+++ b/exercises/practice/binary-search/binary-search.coffee
@@ -2,18 +2,5 @@ class BinarySearch
   constructor: (@array) ->
 
   find: (value) ->
-    start = 0
-    end = @array.length - 1
-    while start <= end
-        mid = (start + end) // 2
-        item = @array.get mid
-        if value == item
-            return mid
-        else if value <= item
-            end = mid - 1
-        else if value >= item
-            start = mid + 1
-
-    throw new Error 'value not in array'
 
 module.exports = BinarySearch

--- a/exercises/practice/binary-search/binary-search.coffee
+++ b/exercises/practice/binary-search/binary-search.coffee
@@ -1,5 +1,5 @@
 class BinarySearch
-  constructor: (@array) ->
+  constructor: (array) ->
 
   find: (value) ->
 

--- a/exercises/practice/binary-search/binary-search.spec.coffee
+++ b/exercises/practice/binary-search/binary-search.spec.coffee
@@ -1,62 +1,63 @@
 BinarySearch = require './binary-search'
+TracedArray = require './traced-array'
 
 describe 'Binary Search', ->
   it 'finds a value in an array wxith one element', ->
-    array = [6]
-    result = new BinarySearch(array).find 6
-    expect(result).toBe 0
+    array = new TracedArray 6
+    expect(new BinarySearch(array).find 6).toBe 0
+    expect(array.accessCount).toBe 1
 
   xit 'finds a value in the middle of an array', ->
-    array = [1, 3, 4, 6, 8, 9, 11]
-    result = new BinarySearch(array).find 6
-    expect(result).toBe 3
+    array = new TracedArray 1, 3, 4, 6, 8, 9, 11
+    expect(new BinarySearch(array).find 6).toBe 3
+    expect(array.accessCount).toBe 1
 
   xit 'finds a value at the beginning of an array', ->
-    array = [1, 3, 4, 6, 8, 9, 11]
-    result = new BinarySearch(array).find 1
-    expect(result).toBe 0
+    array = new TracedArray 1, 3, 4, 6, 8, 9, 11
+    expect(new BinarySearch(array).find 1).toBe 0
+    expect(array.accessCount).toBe 3
 
   xit 'finds a value at the end of an array', ->
-    array = [1, 3, 4, 6, 8, 9, 11]
-    result = new BinarySearch(array).find 11
-    expect(result).toBe 6
+    array = new TracedArray 1, 3, 4, 6, 8, 9, 11
+    expect(new BinarySearch(array).find 11).toBe 6
+    expect(array.accessCount).toBe 3
 
   xit 'finds a value in an array of odd length', ->
-    array = [1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 634]
-    result = new BinarySearch(array).find 144
-    expect(result).toBe 9
+    array = new TracedArray 1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 634
+    expect(new BinarySearch(array).find 144).toBe 9
+    expect(array.accessCount).toBe 2
 
   xit 'finds a value in an array of even length', ->
-    array = [1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377]
-    result = new BinarySearch(array).find 21
-    expect(result).toBe 5
+    array = new TracedArray 1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377
+    expect(new BinarySearch(array).find 21).toBe 5
+    expect(array.accessCount).toBe 1
 
   xit 'identifies that a value is not included in the array', ->
-    array = [1, 3, 4, 6, 8, 9, 11]
+    array = new TracedArray 1, 3, 4, 6, 8, 9, 11
     expect ->
       new BinarySearch(array).find 7
     .toThrow new Error 'value not in array'
 
   xit "a value smaller than the array's smallest value is not found", ->
-    array = [1, 3, 4, 6, 8, 9, 11]
+    array = new TracedArray 1, 3, 4, 6, 8, 9, 11
     expect ->
       new BinarySearch(array).find 0
     .toThrow new Error 'value not in array'
 
   xit "a value larger than the array's largest value is not found", ->
-    array = [1, 3, 4, 6, 8, 9, 11]
+    array = new TracedArray 1, 3, 4, 6, 8, 9, 11
     expect ->
       new BinarySearch(array).find 13
     .toThrow new Error 'value not in array'
 
   xit 'nothing is found in an empty array', ->
-    array = []
+    array = new TracedArray
     expect ->
       new BinarySearch(array).find 1
     .toThrow new Error 'value not in array'
 
   xit 'nothing is found when the left and right bounds cross', ->
-    array = [1, 2]
+    array = new TracedArray 1, 2
     expect ->
       new BinarySearch(array).find 0
     .toThrow new Error 'value not in array'

--- a/exercises/practice/binary-search/traced-array.coffee
+++ b/exercises/practice/binary-search/traced-array.coffee
@@ -1,0 +1,13 @@
+class TracedArray
+  constructor: (values...) ->
+    data = values
+    @accessCount = 0
+
+    @get = (index) =>
+      @accessCount += 1
+      data[index]
+    
+    Object.defineProperty @, 'length',
+      get: -> data.length
+
+module.exports = TracedArray


### PR DESCRIPTION
Inspired by https://github.com/exercism/lua/blob/main/exercises/practice/binary-search/TracedArray.lua, this proposed change tracks how often the input values are accessed so a binary search algorithm must be implemented.

This is a `maintained-autonomous` repo so no review is needed, but I'd like to get a second set of eyeballs so I'm pinging @exercism/cross-track-maintainers. 